### PR TITLE
Make it possible to post message to editor from another domain

### DIFF
--- a/api.js
+++ b/api.js
@@ -171,7 +171,7 @@
 
     function postMessageToEditor(data) {
         var editorWindow = window.top;
-        editorWindow.postMessage(data, editorWindow.location.href);
+        editorWindow.postMessage(data, '*');
     }
 
     function sendNotificationToEditor(message, isSuccess) {


### PR DESCRIPTION
When editor and template are on different domains editorWindow.location.href is not accessible and throws an exception. '*' is a temporary solution, hopefully in future we will move settings to the editor
